### PR TITLE
feat: 프롬프트 버전관리 rpc 추가

### DIFF
--- a/com/hearlers/v1/model/counsel.proto
+++ b/com/hearlers/v1/model/counsel.proto
@@ -14,16 +14,17 @@ message Counsel {
     string id = 1;
     string counselor_id = 2;
     string user_id = 3;
-    string last_message = 4;
-    string last_chated_at = 5;
-    string counsel_technique_id = 6;
-    string counselor_user_relationship_id = 7;
+    optional string last_message = 4;
+    optional string last_chated_at = 5;
+    string prompt_version_id = 6;
+    string counsel_technique_id = 7;
+    string counselor_user_relationship_id = 8;
     // ISO 8601 (2024-12-29T12:34:56.000Z)
-    string created_at = 8;
+    string created_at = 9;
     // ISO 8601 (2024-12-29T12:34:56.000Z)
-    string updated_at = 9;
+    string updated_at = 10;
     // ISO 8601 (2024-12-29T12:34:56.000Z)
-    optional string deleted_at = 10;
+    optional string deleted_at = 11;
 }
 
 message CounselMessage {

--- a/com/hearlers/v1/model/counsel_prompt.proto
+++ b/com/hearlers/v1/model/counsel_prompt.proto
@@ -4,10 +4,62 @@ package com.hearlers.v1.model;
 option java_package = "com.hearlers.api.proto.v1.model";
 option java_multiple_files = true;
 
-message Tone {
+message PromptVersion {
     string id = 1;
     string name = 2;
-    string body = 3;
+    string description = 3;
+    bool is_active = 4;
+    bool is_temporary = 5;
+    bool is_bookmarked = 6;
+    repeated PromptByCounselor prompt_by_counselors= 7;
+    repeated PromptByTone prompt_by_tones = 8;
+    // ISO 8601 (2024-12-29T12:34:56.000Z)
+    string created_at = 9;
+    // ISO 8601 (2024-12-29T12:34:56.000Z)
+    string updated_at = 10;
+    // ISO 8601 (2024-12-29T12:34:56.000Z)
+    optional string deleted_at = 11;
+}
+
+message PromptByCounselor {
+    string counselor_id = 1;
+    string persona_prompt_id = 2;
+    // ISO 8601 (2024-12-29T12:34:56.000Z)
+    string created_at = 3;
+    // ISO 8601 (2024-12-29T12:34:56.000Z)
+    string updated_at = 4;
+    // ISO 8601 (2024-12-29T12:34:56.000Z)
+    optional string deleted_at = 5;
+}
+
+message PromptByTone {
+    string tone_id = 1;
+    optional string tone_prompt_id = 2;
+    optional string first_counsel_technique_id = 3;
+    // ISO 8601 (2024-12-29T12:34:56.000Z)
+    string created_at = 4;
+    // ISO 8601 (2024-12-29T12:34:56.000Z)
+    string updated_at = 5;
+    // ISO 8601 (2024-12-29T12:34:56.000Z)
+    optional string deleted_at = 6;
+}
+
+message PersonaPrompt {
+    string id = 1;
+    string body = 2;
+    string counselor_id = 3;
+    // ISO 8601 (2024-12-29T12:34:56.000Z)
+    string created_at = 4;
+    // ISO 8601 (2024-12-29T12:34:56.000Z)
+    string updated_at = 5;
+    // ISO 8601 (2024-12-29T12:34:56.000Z)
+    optional string deleted_at = 6;
+}
+
+message TonePrompt {
+    string id = 1;
+    string body = 2;
+    string tone_id = 3;
     // ISO 8601 (2024-12-29T12:34:56.000Z)
     string created_at = 4;
     // ISO 8601 (2024-12-29T12:34:56.000Z)
@@ -23,11 +75,25 @@ message CounselTechnique {
     string context = 4;
     string instruction = 5;
     int32 message_threshold = 6;
-    optional string next_counsel_technique_id = 7;
+    bool is_temporary = 7;
+    optional string next_counsel_technique_id = 8;
     // ISO 8601 (2024-12-29T12:34:56.000Z)
-    string created_at = 8;
+    string created_at = 9;
     // ISO 8601 (2024-12-29T12:34:56.000Z)
-    string updated_at = 9;
+    string updated_at = 10;
     // ISO 8601 (2024-12-29T12:34:56.000Z)
-    optional string deleted_at = 10;
+    optional string deleted_at = 11;
+}
+
+message PromptActivateHistory {
+    string id = 1;
+    string prompt_version_id = 2;
+    // ISO 8601 (2024-12-29T12:34:56.000Z)
+    string activated_at = 3;
+    // ISO 8601 (2024-12-29T12:34:56.000Z)
+    string created_at = 4;
+    // ISO 8601 (2024-12-29T12:34:56.000Z)
+    string updated_at = 5;
+    // ISO 8601 (2024-12-29T12:34:56.000Z)
+    optional string deleted_at = 6;
 }

--- a/com/hearlers/v1/model/counsel_prompt.proto
+++ b/com/hearlers/v1/model/counsel_prompt.proto
@@ -11,8 +11,8 @@ message PromptVersion {
     bool is_active = 4;
     bool is_temporary = 5;
     bool is_bookmarked = 6;
-    repeated PromptByCounselor prompt_by_counselors= 7;
-    repeated PromptByTone prompt_by_tones = 8;
+    repeated CounselorScopedPrompt counselor_scoped_prompts = 7;
+    repeated ToneScopedPrompt tone_scoped_prompts = 8;
     // ISO 8601 (2024-12-29T12:34:56.000Z)
     string created_at = 9;
     // ISO 8601 (2024-12-29T12:34:56.000Z)
@@ -21,7 +21,7 @@ message PromptVersion {
     optional string deleted_at = 11;
 }
 
-message PromptByCounselor {
+message CounselorScopedPrompt {
     string counselor_id = 1;
     string persona_prompt_id = 2;
     // ISO 8601 (2024-12-29T12:34:56.000Z)
@@ -32,7 +32,7 @@ message PromptByCounselor {
     optional string deleted_at = 5;
 }
 
-message PromptByTone {
+message ToneScopedPrompt {
     string tone_id = 1;
     optional string tone_prompt_id = 2;
     optional string first_counsel_technique_id = 3;

--- a/com/hearlers/v1/model/counselor.proto
+++ b/com/hearlers/v1/model/counselor.proto
@@ -17,22 +17,21 @@ message Counselor {
     string name = 3;
     string description = 4;
     CounselorGender gender = 5;
-    Persona persona = 6;
-    string intro_message = 7;
-    string response_option1 = 8;
-    string response_option2 = 9;
+    string intro_message = 6;
+    string response_option1 = 7;
+    string response_option2 = 8;
     // ISO 8601 (2024-12-29T12:34:56.000Z)
-    string created_at = 10;
+    string created_at = 9;
     // ISO 8601 (2024-12-29T12:34:56.000Z)
-    string updated_at = 11;
+    string updated_at = 10;
     // ISO 8601 (2024-12-29T12:34:56.000Z)
-    optional string deleted_at = 12;
+    optional string deleted_at = 11;
 }
 
-message Persona {
+message Tone {
     string id = 1;
-    string body = 2;
-    string counselor_id = 3;
+    string name = 2;
+    string description = 3;
     // ISO 8601 (2024-12-29T12:34:56.000Z)
     string created_at = 4;
     // ISO 8601 (2024-12-29T12:34:56.000Z)

--- a/com/hearlers/v1/service/counsel.proto
+++ b/com/hearlers/v1/service/counsel.proto
@@ -32,6 +32,7 @@ service CounselService {
 
 
 // 상담
+// 현재 활성화된 프롬프트 버전 적용
 message CreateCounselRequest {
     string user_id = 1;                       
     string counselor_id = 2;

--- a/com/hearlers/v1/service/counsel_prompt.proto
+++ b/com/hearlers/v1/service/counsel_prompt.proto
@@ -8,59 +8,135 @@ option java_package = "com.hearlers.api.proto.v1.service";
 option java_multiple_files = true;
 
 service CounselPromptService {
-    // Tone
-    rpc CreateTone (CreateToneRequest) returns (CreateToneResponse);
-    rpc FindTones (FindTonesRequest) returns (FindTonesResponse);
-    rpc FindToneById (FindToneByIdRequest) returns (FindToneByIdResponse);
-    rpc UpdateTone (UpdateToneRequest) returns (UpdateToneResponse);
+    // prompt version
+    rpc FindPromptVersions (FindPromptVersionsRequest) returns (FindPromptVersionsResponse);
+    rpc FindPromptVersionById (FindPromptVersionByIdRequest) returns (FindPromptVersionByIdResponse);
+    rpc FindTemporaryVersion (FindTemporaryVersionRequest) returns (FindTemporaryVersionResponse);
+    rpc LoadExistingPromptVersion (LoadExistingPromptVersionRequest) returns (LoadExistingPromptVersionResponse);
+    rpc SaveTemporaryVersion (SaveTemporaryVersionRequest) returns (SaveTemporaryVersionResponse);
+    rpc ActivatePromptVersion (ActivatePromptVersionRequest) returns (ActivatePromptVersionResponse);
 
-    // 상담 기법
+    // persona prompt
+    rpc FindPersonaPromptById (FindPersonaPromptByIdRequest) returns (FindPersonaPromptByIdResponse);
+    rpc UpdatePersonaPrompt (UpdatePersonaPromptRequest) returns (UpdatePersonaPromptResponse);
+    
+    // tone prompt
+    rpc FindTonePromptById (FindTonePromptByIdRequest) returns (FindTonePromptByIdResponse);
+    rpc UpdateTonePrompt (UpdateTonePromptRequest) returns (UpdateTonePromptResponse);
+
+    // counsel technique
     rpc CreateCounselTechnique (CreateCounselTechniqueRequest) returns (CreateCounselTechniqueResponse);
     rpc FindCounselTechniques (FindCounselTechniquesRequest) returns (FindCounselTechniquesResponse);
     rpc FindCounselTechniqueById (FindCounselTechniqueByIdRequest) returns (FindCounselTechniqueByIdResponse);
     rpc UpdateCounselTechnique (UpdateCounselTechniqueRequest) returns (UpdateCounselTechniqueResponse);
     rpc SaveCounselTechniqueSequence (SaveCounselTechniqueSequenceRequest) returns (SaveCounselTechniqueSequenceResponse);
+
+    // prompt activate history
+    rpc FindPromptActivateHistories (FindPromptActivateHistoriesRequest) returns (FindPromptActivateHistoriesResponse);
 }
 
-
-// Tone
-message CreateToneRequest {
-    string name = 1;
-    string body = 2;
-}
-
-message CreateToneResponse {
-    com.hearlers.v1.model.Tone tone = 1;
-}
-
-message FindTonesRequest {
+// prompt version
+message FindPromptVersionsRequest {
     optional string name = 1;
 }
 
-message FindTonesResponse {
-    repeated com.hearlers.v1.model.Tone tones = 1;
+message FindPromptVersionsResponse {
+    repeated com.hearlers.v1.model.PromptVersion prompt_versions = 1;
 }
 
-message FindToneByIdRequest {
+message FindPromptVersionByIdRequest {
+    string prompt_version_id = 1;
+}
+
+message FindPromptVersionByIdResponse {
+    optional com.hearlers.v1.model.PromptVersion prompt_version = 1;
+}
+
+// 현재 수정중인 임시버전 조회
+// 수정중인 임시버전이 없을 경우, 새롭게 생성 및 현재 활성화 버전 복사
+message FindTemporaryVersionRequest {}
+
+message FindTemporaryVersionResponse {
+    optional com.hearlers.v1.model.PromptVersion prompt_version = 1;
+}
+
+// 저장된 버전을 임시버전으로 복사
+message LoadExistingPromptVersionRequest {
+    string prompt_version_id = 1;
+}
+
+message LoadExistingPromptVersionResponse {
+    optional com.hearlers.v1.model.PromptVersion prompt_version = 1;
+}
+
+// 임시버전 저장
+message SaveTemporaryVersionRequest {
+    string name = 1;
+    string description = 2;
+}
+
+message SaveTemporaryVersionResponse {
+    optional com.hearlers.v1.model.PromptVersion prompt_version = 1;
+}
+
+// 저장된 버전 활성화(서비스 반영)
+// 이후 생성되는 상담들부터 해당 버전 적용(기존 상담들 영향 x)
+// 임시버전은 활성화 불가
+message ActivatePromptVersionRequest {
+    string prompt_version_id = 1;
+}
+
+message ActivatePromptVersionResponse {
+    optional com.hearlers.v1.model.PromptVersion prompt_version = 1;
+}
+
+
+// persona prompt
+// 불변객체(수정 시 새로운 객체 생성)
+message FindPersonaPromptByIdRequest {
+    string persona_prompt_id = 1;
+}
+
+message FindPersonaPromptByIdResponse {
+    optional com.hearlers.v1.model.PersonaPrompt persona_prompt = 1;
+}
+
+// 임시버전에서 수정
+message UpdatePersonaPromptRequest {
+    string counselor_id = 1;
+    string body = 2;
+}
+
+message UpdatePersonaPromptResponse {
+    optional com.hearlers.v1.model.PersonaPrompt persona_prompt = 1;
+}
+
+
+// tone prompt
+// 불변객체(수정 시 새로운 객체 생성)
+message FindTonePromptByIdRequest {
+    string tone_prompt_id = 1;
+}
+
+message FindTonePromptByIdResponse {
+    optional com.hearlers.v1.model.TonePrompt tone_prompt = 1;
+}
+
+// 임시버전에서 수정
+message UpdateTonePromptRequest {
     string tone_id = 1;
+    string body = 2;
 }
 
-message FindToneByIdResponse {
-    optional com.hearlers.v1.model.Tone tone = 1;
-}
-
-message UpdateToneRequest {
-    string tone_id = 1;
-    optional string name = 2;
-    optional string body = 3;
-}
-
-message UpdateToneResponse {
-    com.hearlers.v1.model.Tone tone = 1;
+message UpdateTonePromptResponse {
+    optional com.hearlers.v1.model.TonePrompt tone_prompt = 1;
 }
 
 
-// 상담 기법
+// counsel technique
+// 불변객체(수정 시 새로운 객체 생성)
+// 임시기법(다른 기법들과 링크x)으로 생성
+// 추후 순서지정 필요
 message CreateCounselTechniqueRequest {
     string name = 1;
     string tone_id = 2;
@@ -89,7 +165,10 @@ message FindCounselTechniqueByIdRequest {
 message FindCounselTechniqueByIdResponse {
     optional com.hearlers.v1.model.CounselTechnique counsel_technique = 1;
 }
-    
+
+// 임시버전에서 수정
+// 아직 링크되지 않은 임시기법은 수정 불가
+// 수정 후 해당 기법이 포함된 기법리스트 반환
 message UpdateCounselTechniqueRequest {
     string counsel_technique_id = 1;
     optional string name = 2;
@@ -99,14 +178,27 @@ message UpdateCounselTechniqueRequest {
 }
 
 message UpdateCounselTechniqueResponse {
-    com.hearlers.v1.model.CounselTechnique counsel_technique = 1;
+    repeated com.hearlers.v1.model.CounselTechnique counsel_techniques = 1;
 }
 
+// 임시버전에서 수정
+// 기존 기법 및 임시기법들을 연결
+// 연결된 최종 기법 리스트 반환
 message SaveCounselTechniqueSequenceRequest {
-    string toneId = 1;
+    string tone_id = 1;
     repeated string counsel_technique_ids = 2;
 }
 
 message SaveCounselTechniqueSequenceResponse {
     repeated com.hearlers.v1.model.CounselTechnique counsel_techniques = 1;
+}
+
+
+// prompt activate history
+message FindPromptActivateHistoriesRequest {
+    optional string prompt_version_id = 1;
+}
+
+message FindPromptActivateHistoriesResponse {
+    repeated com.hearlers.v1.model.PromptActivateHistory prompt_activate_histories = 1;
 }

--- a/com/hearlers/v1/service/counsel_prompt.proto
+++ b/com/hearlers/v1/service/counsel_prompt.proto
@@ -26,7 +26,7 @@ service CounselPromptService {
 
     // counsel technique
     rpc CreateCounselTechnique (CreateCounselTechniqueRequest) returns (CreateCounselTechniqueResponse);
-    rpc FindCounselTechniques (FindCounselTechniquesRequest) returns (FindCounselTechniquesResponse);
+    rpc FindOrderedCounselTechniques (FindOrderedCounselTechniquesRequest) returns (FindOrderedCounselTechniquesResponse);
     rpc FindCounselTechniqueById (FindCounselTechniqueByIdRequest) returns (FindCounselTechniqueByIdResponse);
     rpc UpdateCounselTechnique (UpdateCounselTechniqueRequest) returns (UpdateCounselTechniqueResponse);
     rpc SaveCounselTechniqueSequence (SaveCounselTechniqueSequenceRequest) returns (SaveCounselTechniqueSequenceResponse);
@@ -149,12 +149,11 @@ message CreateCounselTechniqueResponse {
     com.hearlers.v1.model.CounselTechnique counsel_technique = 1;
 }
 
-message FindCounselTechniquesRequest {
-    optional string name = 1;
-    optional string tone_id = 2;
+message FindOrderedCounselTechniquesRequest {
+    string first_counsel_technique_id = 1;
 }
 
-message FindCounselTechniquesResponse {
+message FindOrderedCounselTechniquesResponse {
     repeated com.hearlers.v1.model.CounselTechnique counsel_techniques = 1;
 }
 

--- a/com/hearlers/v1/service/counselor.proto
+++ b/com/hearlers/v1/service/counselor.proto
@@ -13,6 +13,12 @@ service CounselorService {
     rpc FindCounselors (FindCounselorsRequest) returns (FindCounselorsResponse);
     rpc FindCounselorById (FindCounselorByIdRequest) returns (FindCounselorByIdResponse);
     rpc UpdateCounselor (UpdateCounselorRequest) returns (UpdateCounselorResponse);
+
+    // 톤
+    rpc CreateTone (CreateToneRequest) returns (CreateToneResponse);
+    rpc FindTones (FindTonesRequest) returns (FindTonesResponse);
+    rpc FindToneById (FindToneByIdRequest) returns (FindToneByIdResponse);
+    rpc UpdateTone (UpdateToneRequest) returns (UpdateToneResponse);
 }
 
 // 상담사
@@ -21,7 +27,6 @@ message CreateCounselorRequest {
     string name = 2;
     string description = 3;
     com.hearlers.v1.model.CounselorGender counselor_gender = 4;
-    string persona = 5;
 }
 
 message CreateCounselorResponse {
@@ -50,9 +55,45 @@ message UpdateCounselorRequest {
     optional string name = 3;
     optional string description = 4;
     optional com.hearlers.v1.model.CounselorGender counselor_gender = 5;
-    optional string persona = 6;
 }
 
 message UpdateCounselorResponse {
     com.hearlers.v1.model.Counselor counselor = 1;
+}
+
+
+// 톤
+message CreateToneRequest {
+    string name = 1;
+    string description = 2;
+}
+
+message CreateToneResponse {
+    com.hearlers.v1.model.Tone tone = 1;
+}
+
+message FindTonesRequest {
+    optional string name = 1;
+}
+
+message FindTonesResponse {
+    repeated com.hearlers.v1.model.Tone tones = 1;
+}
+
+message FindToneByIdRequest {
+    string tone_id = 1;
+}
+
+message FindToneByIdResponse {
+    optional com.hearlers.v1.model.Tone tone = 1;
+}
+
+message UpdateToneRequest {
+    string tone_id = 1;
+    optional string name = 2;
+    optional string description = 3;
+}
+
+message UpdateToneResponse {
+    com.hearlers.v1.model.Tone tone = 1;
 }


### PR DESCRIPTION
프롬프트 버전관리를 위한 모델 및 rpc 서비스를 정의하였습니다.

- persona prompt, tone prompt 를 counselor 와 tone 으로부터 분리
- 상담 시작 시 지정된 프롬프트 버전을 통해 해당 상담사 및 톤에 따른 프롬프트에 접근
- 기존 버전의 불변성 유지를 위해 프롬프트 객체들(persona prompt, tone prompt, counsel technique)은 불변객체로 관리 및 수정 시 새로운 객체 생성

아직까지 이게 올바른 구조 및 서비스 설계인지 감이 잘 안와서 자유롭게 의견주시면 감사하겠습니다.
api쪽 구현이 아직 덜 되서 해당 부분 구현 마무리 되면 한꺼번에 머지하는게 좋을 것 같습니다.