### PR TITLE
Refactor/counsel

### DIFF
--- a/com/hearlers/v1/model/counsel.proto
+++ b/com/hearlers/v1/model/counsel.proto
@@ -18,14 +18,12 @@ message Counsel {
   optional string last_message = 4;
   optional string last_chated_at = 5;
   string prompt_version_id = 6;
-  string counsel_technique_id = 7;
-  string counselor_user_relationship_id = 8;
   // ISO 8601 (2024-12-29T12:34:56.000Z)
-  string created_at = 9;
+  string created_at = 7;
   // ISO 8601 (2024-12-29T12:34:56.000Z)
-  string updated_at = 10;
+  string updated_at = 8;
   // ISO 8601 (2024-12-29T12:34:56.000Z)
-  optional string deleted_at = 11;
+  optional string deleted_at = 9;
 }
 
 message CounselMessage {

--- a/com/hearlers/v1/service/counsel.proto
+++ b/com/hearlers/v1/service/counsel.proto
@@ -22,11 +22,8 @@ service CounselService {
   rpc ReactMessage(ReactMessageRequest) returns (ReactMessageResponse);
 
   // 상담사와 유저의 관계
-  // TODO: CQRS 패턴으로 뷰 테이블을 만들어 놓고 그냥 꺼내서 준다.
-  // Relationship은 읽을 시 싱딤시와, 상담사의 모든 Counsels를 다 가지고 오는게 의미있는 단위
-  // Relationship 뷰 테이블에 이미 상담사와 모든 유저의 대화 내용을 미리 조인해둔 뷰 테이블을 만들어 놓고 그냥 꺼내서 준다.
-  // DDD를 안함
-  // 별도의 모듈
+  rpc FindCounselorUserRelationshipById(FindCounselorUserRelationshipByIdRequest) returns (FindCounselorUserRelationshipByIdResponse);
+  rpc FindCounselorUserRelationshipByUserAndCounselorId(FindCounselorUserRelationshipByUserAndCounselorIdRequest) returns (FindCounselorUserRelationshipByUserAndCounselorIdResponse);
   rpc FindCounselorUserRelationships(FindCounselorUserRelationshipsRequest) returns (FindCounselorUserRelationshipsResponse);
 }
 
@@ -91,9 +88,25 @@ message ReactMessageResponse {
 }
 
 // 상담사와 유저의 관계
+message FindCounselorUserRelationshipByIdRequest {
+  string relationship_id = 1;
+}
+
+message FindCounselorUserRelationshipByIdResponse {
+  optional com.hearlers.v1.model.CounselorUserRelationship counselor_user_relationship = 1;
+}
+
+message FindCounselorUserRelationshipByUserAndCounselorIdRequest {
+  string user_id = 1;
+  string counselor_id = 2;
+}
+
+message FindCounselorUserRelationshipByUserAndCounselorIdResponse {
+  optional com.hearlers.v1.model.CounselorUserRelationship counselor_user_relationship = 1;
+}
+
 message FindCounselorUserRelationshipsRequest {
-  string counselor_id = 1;
-  string user_id = 2;
+  string user_id = 1;
 }
 
 message FindCounselorUserRelationshipsResponse {


### PR DESCRIPTION
상담 객체에 기법id 와 유저-상담사 관게id 필드 제거하였습니다.
기법id 는 더이상 상담객체에서 다루지 않고 context 라는 별개의 객체에서 다루고 있고,
관계 정보는 한 상담사 당 여러 상담이 존재하게 됨에 따라 상담 별로 할당되는 구조가 아니게 되어서 제거하는게 맞을 것 같습니다.

추가로 관계정보 조회 메서드 수정하였습니다.
- id 로 단일객체 조회
- 사용자id 및 상담사id로 단일객체 조회
- 사용자id로 복수객체 조회

총 3개의 메서드로 구성하였습니다.